### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conradj3/azure-kubernetes-credential-loader/security/code-scanning/7](https://github.com/conradj3/azure-kubernetes-credential-loader/security/code-scanning/7)

To address this issue, the workflow should be amended to declare a `permissions:` block at the top level under the workflow root (directly below `name:` and/or above `on:`). This will restrict the permissions of the `GITHUB_TOKEN` for all jobs unless overridden on a per-job basis. Since none of the jobs in the workflow appear to require write access to repository contents or pull requests, the least privilege configuration is to set `contents: read`. If in the future any job needs additional permissions (e.g., commenting on pull requests), those can be set at the job level. 

**Action:**  
- Insert a `permissions:` block at the workflow root of `.github/workflows/ci.yml`, immediately after the `name:` line and before the `on:` block.
- Set `contents: read`.

**No other changes to workflow logic are required, and no new dependencies.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
